### PR TITLE
🐳 Set up Docker container for the database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+db:
+  image: postgres:11.2-alpine
+  environment:
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=postgres
+    - POSTGRES_HOST=db


### PR DESCRIPTION
Use the instructions in https://blog.codeship.com/running-your-phoenix-tests-using-docker/ to set up a Docker container to run Postgres.  I'm using the `-alpine` image instead of the standard one to keep things smaller.

Tested as follows:

```console
$ docker-compose up -d db

$ docker ps
CONTAINER ID        IMAGE                  COMMAND                  CREATED             STATUS              PORTS               NAMES
164762ed9e12        postgres:11.2-alpine   "docker-entrypoint.s…"   9 seconds ago       Up 7 seconds        5432/tcp            freedomaccount_db_1

$ docker-compose exec db psql -U postgres
psql (11.2)
Type "help" for help.

postgres=# \l
                                 List of databases
   Name    |  Owner   | Encoding |  Collate   |   Ctype    |   Access privileges
-----------+----------+----------+------------+------------+-----------------------
 postgres  | postgres | UTF8     | en_US.utf8 | en_US.utf8 |
 template0 | postgres | UTF8     | en_US.utf8 | en_US.utf8 | =c/postgres          +
           |          |          |            |            | postgres=CTc/postgres
 template1 | postgres | UTF8     | en_US.utf8 | en_US.utf8 | =c/postgres          +
           |          |          |            |            | postgres=CTc/postgres
(3 rows)

postgres=# \du
                                   List of roles
 Role name |                         Attributes                         | Member of
-----------+------------------------------------------------------------+-----------
 postgres  | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
```

Closes #5
