### PR TITLE
🎨 Set up Elixir formatter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "./server:/app"
 
   server_test:
-    command: mix test
+    command: mix test.all
     depends_on:
       - db
     env_file:

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -55,7 +55,8 @@ defmodule FreedomAccount.MixProject do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate", "test"],
+      "test.all": ["format --check-formatted", "test"]
     ]
   end
 end

--- a/server/test/freedom_account_web/views/error_view_test.exs
+++ b/server/test/freedom_account_web/views/error_view_test.exs
@@ -5,7 +5,9 @@ defmodule FreedomAccountWeb.ErrorViewTest do
   import Phoenix.View
 
   test "renders 404.json" do
-    assert render(FreedomAccountWeb.ErrorView, "404.json", []) == %{errors: %{detail: "Not Found"}}
+    assert render(FreedomAccountWeb.ErrorView, "404.json", []) == %{
+             errors: %{detail: "Not Found"}
+           }
   end
 
   test "renders 500.json" do


### PR DESCRIPTION
Add a `test.all` alias that runs the unit tests and checks that all files are formatted.  Make this the default command for the `server_test` container.

Files can be formatted with `docker-compose exec server mix format` as needed.

In-editor formatting seems to work OK, but that might be because I have a version of Elixir installed on my workstation.

There doesn't seem to be a way to get the Elixir language server to run from the Docker container, so a new strategy will be required (future PR).

Closes #16 
