### PR TITLE
🐳 Restore server_test container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.db/data/
-config/docker_prod_secret.env
+/config/docker_prod_secret.env

--- a/README.md
+++ b/README.md
@@ -19,15 +19,20 @@ scratchpad to remind myself how to do things:
 - Run the server in development mode: `docker-compose up -d server`
 - Build the production app: `docker-compose -f docker-compose-prod.yml -p freedom_account_prod build`
 - Run the production app: `docker-compose -f docker-compose-prod.yml -p freedom_account_prod up -d`
+- Run all server tests/linting/type-checking/format-checking:
+  `docker-compose up server_test`
+- Run an individual test-related command:
+  `docker-compose run --rm server_test <command>`,
+  where command is one of:
+  - `mix test`
+  - `mix credo`
+  - `mix dialyzer`
+  - `mix format`
+  - `mix test.watch`
 
-Local commands (run from the `server` directory):
+To install locally (for use in editor integration):
 - Install dependencies (requires [asdf](https://github.com/asdf-vm/asdf)): `asdf install`
-- Run tests: `mix test`
-- Run tests in watch mode: `mix test.watch`
-- Run linting: `mix credo`
-- Run type checks: `mix dialyzer`
-- Format the code: `mix format`
-- Run all server tests/linting/type-checking/format-checking: `MIX_ENV=test mix test.all`
+- `cd server && mix do deps.get, deps.compile`
 
 ## Approach
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,10 @@ services:
     volumes:
       - dbdata:/var/lib/postgresql/data
   db_setup:
-    build: ./server
+    build:
+      args:
+        - MIX_ENV=dev
+      context: ./server
     command: ./scripts/wait-for-it.sh db:5432 --strict -t 30 -- mix ecto.setup
     depends_on:
       - db
@@ -27,9 +30,25 @@ services:
     ports:
       - "4000:4000"
     volumes:
-      - "./server/config:/app/config"
-      - "./server/lib:/app/lib"
-      - "./server/priv:/app/priv"
+      - "./server/config:/app/config:ro"
+      - "./server/lib:/app/lib:ro"
+      - "./server/priv:/app/priv:ro"
+  server_test:
+    build:
+      args:
+        - MIX_ENV=test
+      context: ./server
+    command: ./scripts/wait-for-it.sh db:5432 --strict -t 30 -- mix test.all
+    depends_on:
+      - db
+    env_file:
+      - ./config/docker_test.env
+    volumes:
+      - "./server/config:/app/config:ro"
+      - "./server/lib:/app/lib:ro"
+      - "./server/_plts:/app/_plts"
+      - "./server/priv:/app/priv:ro"
+      - "./server/test:/app/test:ro"
 
 volumes:
   dbdata:

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -5,4 +5,3 @@ priv/static
 Dockerfile*
 README*
 .gitignore
-.formatter.exs

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -36,3 +36,5 @@ freedom_account-*.tar
 /config/*.secret.exs
 
 .elixir_ls/
+
+/_plts/

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,11 +4,15 @@ LABEL maintainer="Randy Coulman <randy@randycoulman.com>"
 WORKDIR /app
 
 RUN \
+  apt-get update && \
+  apt-get install --yes inotify-tools && \
   mix local.hex --force && \
   mix local.rebar --force
 
 COPY mix.exs mix.lock ./
 COPY config ./
+
+ARG MIX_ENV=${MIX_ENV:-dev}
 
 RUN mix do deps.get, deps.compile
 

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -14,7 +14,9 @@ defmodule FreedomAccount.MixProject do
       dialyzer: [
         ignore_warnings: "config/dialyzer_ignore.exs",
         list_unused_filters: true,
-        plt_add_apps: [:ex_unit]
+        plt_add_apps: [:ex_unit],
+        plt_core_path: "_plts",
+        plt_file: {:no_warn, "_plts/dialyzer-#{Mix.env()}.plt"}
       ]
     ]
   end
@@ -44,7 +46,7 @@ defmodule FreedomAccount.MixProject do
       {:ecto_sql, "~> 3.0"},
       {:gettext, "~> 0.11"},
       {:jason, "~> 1.0"},
-      {:mix_test_watch, "~> 0.9", only: :dev, runtime: false},
+      {:mix_test_watch, "~> 0.9", only: [:dev, :test], runtime: false},
       {:phoenix_ecto, "~> 4.0"},
       {:phoenix_pubsub, "~> 1.1"},
       {:phoenix, "~> 1.4.2"},


### PR DESCRIPTION
On second thought, it seems better to have a pre-configured container for running the tests and related tasks.

While we still need a local install for editor integration, we can do everything else in containers.

The restored `server_test` container is configured differently than before.  It uses the exact same `Dockerfile` as the `db_setup`/`server` containers, but runs with `MIX_ENV=test`.

In order to cache dialyzer's PLT files, I've moved them to `server/_plts` and bind-mounted them into the container.

Also:
- Removed the now-obsolete `.db` directory
- Modified bind-mounts to be read-only where possible.