### PR TITLE
🔧 Add test coverage support for client app

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ scratchpad to remind myself how to do things:
 - Run an individual client test-related command:
   `docker-compose run --rm client_test <command>`,
   where command is one of:
-  - `npm test:once`
   - `npm run format`
   - `npm run lint`
   - `npm run lint:format`
   - `npm run lint:js`
+  - `npm run test:coverage`
+  - `npm run test:once`
 
 - For Jest interactivity to work, we need to run tests in watch mode locally,
   rather than in a container:

--- a/client/package.json
+++ b/client/package.json
@@ -11,8 +11,9 @@
     "lint:js": "eslint . --max-warnings 0 --report-unused-disable-directives",
     "start": "craco start",
     "test": "craco test",
+    "test:coverage": "npm test -- --coverage",
     "test:once": "npm test -- --no-watch",
-    "validate": "npm-run-all lint test:once"
+    "validate": "npm-run-all lint test:coverage"
   },
   "dependencies": {
     "@craco/craco": "^3.6.0",
@@ -45,6 +46,12 @@
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"
+    ]
+  },
+  "jest": {
+    "coverageReporters": [
+      "lcov",
+      "text-summary"
     ]
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     build: ./client
     command: npm run validate
     volumes:
+      - "./client/coverage:/app/coverage"
       - "./client/public:/app/public:ro"
       - "./client/src:/app/src:ro"
   db:


### PR DESCRIPTION
Use jest's built-in coverage support and generate an lcov-format HTML report by default.  Bind-mount the `coverage` directory into the `client_test` container so that the HTML stays accessible on the host.

Will decide later if I want to add node-coveralls to hook up to coveralls' service and GitHub integration.

Closes #38 