### PR TITLE
✅ Add simple Cypress test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,10 @@ services:
   e2e:
     build: ./e2e
     command: ./scripts/wait-for-it.sh client:3000 --strict -t 30 -- npm test
-    # depends_on:
-    #   - client
-    # environment:
-    #   - CYPRESS_baseUrl=http://client:3000
+    depends_on:
+      - client
+    environment:
+      - CYPRESS_baseUrl=http://client:3000
     volumes:
       - "./e2e/cypress/screenshots:/app/cypress/screenshots"
       - "./e2e/cypress/videos:/app/cypress/videos"

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,3 +1,4 @@
 {
+  "baseUrl": "http://localhost:3000",
   "video": false
 }

--- a/e2e/cypress/fixtures/example.json
+++ b/e2e/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/e2e/cypress/integration/placeholder.spec.js
+++ b/e2e/cypress/integration/placeholder.spec.js
@@ -1,0 +1,13 @@
+// / <reference types="Cypress" />
+
+context("placeholder", () => {
+  beforeEach(() => {
+    cy.visit("/");
+  });
+
+  describe("home page", () => {
+    it("shows the standard create-react-app message", () => {
+      cy.contains("save to reload").should("exist");
+    });
+  });
+});

--- a/e2e/cypress/plugins/index.js
+++ b/e2e/cypress/plugins/index.js
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+};

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This is will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import "./commands";
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "dev": "cypress open",
     "format": "eslint --fix . && prettier --write \"**/*.{gql,html,js,md}\"",
     "lint": "npm-run-all lint:*",
     "lint:format": "prettier --check \"**/*.{gql,js,md}\"",


### PR DESCRIPTION
Cypress needs at least one test in order to run successfully, so add a simple placeholder test for the out-of-the-box Create React App homepage.

Cypress also generates some other boilerplate files, so add those as well.