### PR TITLE
💚 Improve CI build configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,15 @@ jobs:
     machine: true
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-plt-cache-{{ checksum "server/mix.lock" }}
+            - v1-plt-cache
       - run: docker-compose up --build server_test
+      - save_cache:
+          key: v1-plt-cache-{{ checksum "server/mix.lock" }}
+          paths:
+            - server/_plts
   test_client:
     machine: true
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,26 @@
 version: 2
 jobs:
-  build:
+  test_server:
     machine: true
     steps:
       - checkout
-      - run: docker-compose up server_test client_test e2e
+      - run: docker-compose up --build server_test
+  test_client:
+    machine: true
+    steps:
+      - checkout
+      - run: docker-compose up --build client_test
+  test_e2e:
+    machine: true
+    steps:
+      - checkout
+      - run: docker-compose up --build e2e
       - store_artifacts:
           path: ./e2e/cypress/screenshots
+workflows:
+  version: 2
+  test_all:
+    jobs:
+      - test_server
+      - test_client
+      - test_e2e


### PR DESCRIPTION
- Split CI build into three separate jobs (one each for server, client, and e2e tests)
- Add caching for dialyzer's PLT files