### PR TITLE
🚨 Run e2e lint checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: docker-compose up --build e2e
+      - run: docker-compose up --build e2e_test e2e
       - store_artifacts:
           path: ./e2e/cypress/screenshots
 workflows:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "setup:server": "cd server && mix do deps.get, deps.compile",
     "start": "docker-compose -f docker-compose-prod.yml -p freedom_account_prod up -d",
     "stop": "docker-compose -f docker-compose-prod.yml -p freedom_account_prod down",
-    "test": "docker-compose up --build server_test client_test e2e"
+    "test": "docker-compose up --build server_test client_test e2e_test e2e"
   },
   "devDependencies": {
     "husky": "^1.3.1",


### PR DESCRIPTION
These weren't being run in CI or as part of `npm test`.  Now they are.
