### PR TITLE
👷‍♂️ Use latest Elixir CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2
 jobs:
   test_server:
     docker:
-      - image: cimg/elixir:1.12.2
+      - image: cimg/elixir:1.12.3
       - image: postgres:11.2-alpine
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-server-deps-{{ checksum "server/mix.lock" }}
-            - v1-server-deps
+            - v2-server-deps-{{ checksum "server/mix.lock" }}
+            - v2-server-deps
       - run:
           name: Install dependencies
           command: |
@@ -28,20 +28,20 @@ jobs:
             MIX_ENV: test
           working_directory: server
       - save_cache:
-          key: v1-server-deps-{{ checksum "server/mix.lock" }}
+          key: v2-server-deps-{{ checksum "server/mix.lock" }}
           paths:
             - server/_build
             - server/deps
             - ~/.mix
       - restore_cache:
           keys:
-            - v1-server-plt-{{ checksum "server/mix.lock" }}
-            - v1-server-plt
+            - v2-server-plt-{{ checksum "server/mix.lock" }}
+            - v2-server-plt
       - run:
           command: mix dialyzer --plt
           working_directory: server
       - save_cache:
-          key: v1-server-plt-{{ checksum "server/mix.lock" }}
+          key: v2-server-plt-{{ checksum "server/mix.lock" }}
           paths:
             - server/_build
             - ~/.mix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            mix local.hex --if-missing
+            mix local.hex --force --if-missing
             mix local.rebar --force
             mix deps.get
           working_directory: server


### PR DESCRIPTION
CircleCI's 1.12.3 image was released today, so upgrade to it. It's still one point release behind on Erlang version, though (24.0.5 vs 24.0.6).

Update cache version to bust the cache as is necessary with all language version upgrades.