### PR TITLE
⬆️ Upgrade to prettier 2.4.1

### DIFF
--- a/client/.prettierrc.js
+++ b/client/.prettierrc.js
@@ -1,3 +1,1 @@
-module.exports = {
-  trailingComma: "es5",
-};
+module.exports = {};

--- a/client/craco.config.js
+++ b/client/craco.config.js
@@ -3,7 +3,7 @@ const StylelintBarePlugin = require("stylelint-bare-webpack-plugin");
 
 module.exports = {
   eslint: {
-    loaderOptions: eslintOptions => ({
+    loaderOptions: (eslintOptions) => ({
       ...eslintOptions,
       eslintPath: require.resolve("eslint"),
     }),

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-plugin-react": "^7.12.4",
         "eslint-plugin-react-hooks": "^1.6.0",
         "npm-run-all": "^4.1.5",
-        "prettier": "^1.17.0",
+        "prettier": "^2.4.1",
         "stylelint": "^10.0.1",
         "stylelint-bare-webpack-plugin": "^1.1.1",
         "stylelint-config-prettier": "^5.1.0",
@@ -12195,15 +12195,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
-      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -26464,9 +26464,9 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prettier": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
-      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true
     },
     "pretty-bytes": {

--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-hooks": "^1.6.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.17.0",
+    "prettier": "^2.4.1",
     "stylelint": "^10.0.1",
     "stylelint-bare-webpack-plugin": "^1.1.1",
     "stylelint-config-prettier": "^5.1.0",

--- a/client/src/serviceWorker.js
+++ b/client/src/serviceWorker.js
@@ -63,7 +63,7 @@ export function register(config) {
 function registerValidSW(swUrl, config) {
   navigator.serviceWorker
     .register(swUrl)
-    .then(registration => {
+    .then((registration) => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
 
@@ -101,7 +101,7 @@ function registerValidSW(swUrl, config) {
         };
       };
     })
-    .catch(error => {
+    .catch((error) => {
       console.error("Error during service worker registration:", error);
     });
 }
@@ -109,7 +109,7 @@ function registerValidSW(swUrl, config) {
 function checkValidServiceWorker(swUrl, config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
-    .then(response => {
+    .then((response) => {
       // Ensure service worker exists, and that we really are getting a JS file.
       const contentType = response.headers.get("content-type");
 
@@ -118,7 +118,7 @@ function checkValidServiceWorker(swUrl, config) {
         (contentType != null && contentType.indexOf("javascript") === -1)
       ) {
         // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then(registration => {
+        navigator.serviceWorker.ready.then((registration) => {
           registration.unregister().then(() => {
             window.location.reload();
           });
@@ -137,7 +137,7 @@ function checkValidServiceWorker(swUrl, config) {
 
 export function unregister() {
   if ("serviceWorker" in navigator) {
-    navigator.serviceWorker.ready.then(registration => {
+    navigator.serviceWorker.ready.then((registration) => {
       registration.unregister();
     });
   }

--- a/e2e/.prettierrc.js
+++ b/e2e/.prettierrc.js
@@ -1,3 +1,1 @@
-module.exports = {
-  trailingComma: "es5",
-};
+module.exports = {};

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -18,7 +18,7 @@
         "eslint-plugin-import": "^2.17.2",
         "eslint-plugin-import-helpers": "^0.1.4",
         "npm-run-all": "^4.1.5",
-        "prettier": "^1.17.0"
+        "prettier": "^2.4.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3208,15 +3208,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
-      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -6553,9 +6553,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
-      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true
     },
     "process-nextick-args": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -22,6 +22,6 @@
     "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-import-helpers": "^0.1.4",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.17.0"
+    "prettier": "^2.4.1"
   }
 }


### PR DESCRIPTION
- Remove `es5` trailing comma option as it is now the default
- Reformat to match new rules
