### PR TITLE
⬆️ Upgrade to node 16.13.0 everywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
     default: "14.0"
   nodejs:
     type: string
-    default: 16.12.0
+    default: 16.13.0
 jobs:
   test_server:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.12.0-buster AS client_build
+FROM node:16.13.0-buster AS client_build
 LABEL maintainer="Randy Coulman <randy@randycoulman.com>"
 
 WORKDIR /app


### PR DESCRIPTION
Docker and CI images became available, so start using them.
