### PR TITLE
✨ Edit account settings

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -36,10 +36,10 @@ module.exports = {
       rules: {
         "func-names": "off",
         "jest/consistent-test-it": "warn",
-        //       "jest/expect-expect": [
-        //         "warn",
-        //         { assertFunctionNames: ["expect", "td.verify"] },
-        //       ],
+        "jest/expect-expect": [
+          "warn",
+          { assertFunctionNames: ["expect", "td.verify"] },
+        ],
         "jest/lowercase-name": ["warn", { ignore: ["describe"] }],
         "jest/no-focused-tests": "warn",
         "jest/no-large-snapshots": "warn",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -49,6 +49,7 @@
         "stylelint-config-prettier": "^9.0.3",
         "stylelint-config-standard": "^23.0.0",
         "stylelint-order": "^5.0.0",
+        "testdouble": "^3.16.3",
         "typescript": "^4.4.4"
       }
     },
@@ -22515,6 +22516,20 @@
         }
       ]
     },
+    "node_modules/quibble": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.6.tgz",
+      "integrity": "sha512-qYLELbjh2TagaPEs+sDobJnw166zlYHtT8YibCYxxUYl+pGoDqEVjZZhgQXYPhIivb8CrDtEMP9Oshfu8y6jAQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
     "node_modules/quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -25333,6 +25348,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha1-BXw8mpChJzObudFwSikLt70KHsU=",
+      "dev": true,
+      "dependencies": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -26385,10 +26413,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/testdouble": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.3.tgz",
+      "integrity": "sha512-oxGJ9KFuAJBNrpQEGDLj3OD4jRKLV+NhujRnuw5gYelkkZEFzUExijPi8O26RoVMdhc9C3OanKjvZXinmHWqow==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "quibble": "^0.6.6",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "node_modules/theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
+      "dev": true
     },
     "node_modules/throat": {
       "version": "5.0.0",
@@ -45836,6 +45885,16 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
+    "quibble": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.6.tgz",
+      "integrity": "sha512-qYLELbjh2TagaPEs+sDobJnw166zlYHtT8YibCYxxUYl+pGoDqEVjZZhgQXYPhIivb8CrDtEMP9Oshfu8y6jAQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
+      }
+    },
     "quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -48078,6 +48137,16 @@
         "is-regexp": "^1.0.0"
       }
     },
+    "stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha1-BXw8mpChJzObudFwSikLt70KHsU=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -48833,10 +48902,28 @@
         "minimatch": "^3.0.4"
       }
     },
+    "testdouble": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.3.tgz",
+      "integrity": "sha512-oxGJ9KFuAJBNrpQEGDLj3OD4jRKLV+NhujRnuw5gYelkkZEFzUExijPi8O26RoVMdhc9C3OanKjvZXinmHWqow==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "quibble": "^0.6.6",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
+      "dev": true
     },
     "throat": {
       "version": "5.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -63,6 +63,7 @@
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-standard": "^23.0.0",
     "stylelint-order": "^5.0.0",
+    "testdouble": "^3.16.3",
     "typescript": "^4.4.4"
   },
   "browserslist": {

--- a/client/src/Account.tsx
+++ b/client/src/Account.tsx
@@ -3,19 +3,24 @@ import { gql } from "urql";
 
 import { AccountHeader } from "./AccountHeader";
 import { FundList } from "./FundList";
-import { useMyAccountQuery } from "./graphql";
+import { useMyAccountQuery, useUpdateAccountMutation } from "./graphql";
 
 export const Account = () => {
-  const [{ data, error }] = useMyAccountQuery();
+  const [queryResult] = useMyAccountQuery();
+  const [mutationResult, updateAccount] = useUpdateAccountMutation();
 
-  useErrorHandler(error);
+  useErrorHandler(queryResult.error);
+  useErrorHandler(mutationResult.error);
 
-  const account = data!.myAccount;
+  const account = queryResult.data!.myAccount;
 
   return (
     <>
       <section>
-        <AccountHeader account={account} />
+        <AccountHeader
+          account={account}
+          onUpdate={(input) => updateAccount({ input })}
+        />
       </section>
       <article>
         <h3>Funds</h3>
@@ -28,10 +33,21 @@ export const Account = () => {
 export const AccountQuery = gql`
   query MyAccount {
     myAccount {
+      ...AccountFields
       ...AccountFunds
-      name
     }
   }
 
+  ${AccountHeader.fragments.account}
   ${FundList.fragments.funds}
+`;
+
+export const UpdateAccountMutation = gql`
+  mutation UpdateAccount($input: AccountInput!) {
+    updateAccount(input: $input) {
+      ...AccountFields
+    }
+  }
+
+  ${AccountHeader.fragments.account}
 `;

--- a/client/src/Account.tsx
+++ b/client/src/Account.tsx
@@ -1,6 +1,7 @@
 import { useErrorHandler } from "react-error-boundary";
 import { gql } from "urql";
 
+import { AccountHeader } from "./AccountHeader";
 import { FundList } from "./FundList";
 import { useMyAccountQuery } from "./graphql";
 
@@ -9,16 +10,16 @@ export const Account = () => {
 
   useErrorHandler(error);
 
-  const { funds, name } = data!.myAccount;
+  const account = data!.myAccount;
 
   return (
     <>
       <section>
-        <h2>{name}</h2>
+        <AccountHeader account={account} />
       </section>
       <article>
         <h3>Funds</h3>
-        <FundList funds={funds} />
+        <FundList funds={account.funds} />
       </article>
     </>
   );

--- a/client/src/AccountEditForm.tsx
+++ b/client/src/AccountEditForm.tsx
@@ -1,20 +1,23 @@
-import { assoc, pick } from "ramda";
+import { pick } from "ramda";
 import { ChangeEvent, FormEvent, useState } from "react";
 
-import { Account } from "./graphql";
+import { Account, AccountInput } from "./graphql";
 
 type Props = {
   account: Account;
   onCancel: () => void;
-  onUpdate: (_values: Partial<Account>) => void;
+  onUpdate: (_values: AccountInput) => void;
 };
 
 export const AccountEditForm = ({ account, onCancel, onUpdate }: Props) => {
-  const [values, updateValues] = useState<Partial<Account>>(
+  const [values, updateValues] = useState<AccountInput>(
     pick(["id", "name"], account)
   );
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) =>
-    updateValues(assoc(e.currentTarget.name, e.currentTarget.value));
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.currentTarget;
+
+    updateValues((state) => ({ ...state, [name]: value }));
+  };
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();

--- a/client/src/AccountEditForm.tsx
+++ b/client/src/AccountEditForm.tsx
@@ -1,0 +1,41 @@
+import { assoc, pick } from "ramda";
+import { ChangeEvent, FormEvent, useState } from "react";
+
+import { Account } from "./graphql";
+
+type Props = {
+  account: Account;
+  onCancel: () => void;
+  onUpdate: (_values: Partial<Account>) => void;
+};
+
+export const AccountEditForm = ({ account, onCancel, onUpdate }: Props) => {
+  const [values, updateValues] = useState<Partial<Account>>(
+    pick(["id", "name"], account)
+  );
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) =>
+    updateValues(assoc(e.currentTarget.name, e.currentTarget.value));
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+
+    onUpdate(values);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label htmlFor="name">Name</label>
+      <input
+        id="name"
+        name="name"
+        onChange={handleChange}
+        type="text"
+        value={values.name}
+      />
+      <button type="submit">Update</button>
+      <button onClick={onCancel} type="button">
+        Cancel
+      </button>
+    </form>
+  );
+};

--- a/client/src/AccountEditForm.tsx
+++ b/client/src/AccountEditForm.tsx
@@ -11,12 +11,13 @@ type Props = {
 
 export const AccountEditForm = ({ account, onCancel, onUpdate }: Props) => {
   const [values, updateValues] = useState<AccountInput>(
-    pick(["id", "name"], account)
+    pick(["depositsPerYear", "id", "name"], account)
   );
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.currentTarget;
+    const { name, type, value } = e.currentTarget;
+    const parsedValue = type === "number" ? parseInt(value, 10) : value;
 
-    updateValues((state) => ({ ...state, [name]: value }));
+    updateValues((state) => ({ ...state, [name]: parsedValue }));
   };
 
   const handleSubmit = (e: FormEvent) => {
@@ -34,6 +35,15 @@ export const AccountEditForm = ({ account, onCancel, onUpdate }: Props) => {
         onChange={handleChange}
         type="text"
         value={values.name}
+      />
+      <label htmlFor="depositsPerYear">Deposits / year</label>
+      <input
+        id="depositsPerYear"
+        min={1}
+        name="depositsPerYear"
+        onChange={handleChange}
+        type="number"
+        value={values.depositsPerYear}
       />
       <button type="submit">Update</button>
       <button onClick={onCancel} type="button">

--- a/client/src/AccountHeader.test.tsx
+++ b/client/src/AccountHeader.test.tsx
@@ -44,9 +44,7 @@ it("updates the account and returns to heading on submit", () => {
   userEvent.type(input, "New Name");
   userEvent.click(screen.getByRole("button", { name: /update/i }));
 
-  expect(
-    screen.getByRole("heading", { name: account.name })
-  ).toBeInTheDocument();
+  expect(screen.queryByLabelText(/name/i)).not.toBeInTheDocument();
 
   td.verify(onUpdate({ id: account.id, name: "New Name" }));
 });
@@ -59,9 +57,7 @@ it("returns to heading after cancelling", () => {
   userEvent.click(screen.getByRole("button", { name: /edit/i }));
   userEvent.click(screen.getByRole("button", { name: /cancel/i }));
 
-  expect(
-    screen.getByRole("heading", { name: account.name })
-  ).toBeInTheDocument();
+  expect(screen.queryByLabelText(/name/i)).not.toBeInTheDocument();
 
   td.verify(onUpdate({}), neverCalled);
 });

--- a/client/src/AccountHeader.test.tsx
+++ b/client/src/AccountHeader.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as td from "testdouble";
+
+import { AccountHeader, Props } from "./AccountHeader";
+import { Account } from "./graphql";
+
+const account: Account = {
+  funds: [],
+  id: "1",
+  name: "Initial",
+};
+
+type OnUpdate = Props["onUpdate"];
+const neverCalled = { ignoreExtraArgs: true, times: 0 };
+
+const renderHeader = (props: Partial<Props> = {}) =>
+  render(<AccountHeader account={account} {...props} />);
+
+it("shows a heading by default", () => {
+  renderHeader();
+
+  expect(screen.getByRole("heading")).toHaveTextContent(account.name);
+});
+
+it("allows editing", () => {
+  renderHeader();
+
+  userEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+  expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+});
+
+it("updates the account and returns to heading on submit", () => {
+  const onUpdate = td.func<OnUpdate>();
+
+  renderHeader({ onUpdate });
+
+  userEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+  const input = screen.getByLabelText(/name/i);
+
+  userEvent.clear(input);
+  userEvent.type(input, "New Name");
+  userEvent.click(screen.getByRole("button", { name: /update/i }));
+
+  expect(
+    screen.getByRole("heading", { name: account.name })
+  ).toBeInTheDocument();
+
+  td.verify(onUpdate({ id: account.id, name: "New Name" }));
+});
+
+it("returns to heading after cancelling", () => {
+  const onUpdate = td.func<OnUpdate>();
+
+  renderHeader({ onUpdate });
+
+  userEvent.click(screen.getByRole("button", { name: /edit/i }));
+  userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+  expect(
+    screen.getByRole("heading", { name: account.name })
+  ).toBeInTheDocument();
+
+  td.verify(onUpdate({}), neverCalled);
+});

--- a/client/src/AccountHeader.tsx
+++ b/client/src/AccountHeader.tsx
@@ -1,16 +1,17 @@
 import { useState } from "react";
+import { gql } from "urql";
 
 import { AccountEditForm } from "./AccountEditForm";
-import { Account } from "./graphql";
+import { Account, AccountInput } from "./graphql";
 
 export type Props = {
   account: Account;
-  onUpdate: (_values: Partial<Account>) => void;
+  onUpdate: (_values: AccountInput) => void;
 };
 
 export const AccountHeader = ({ account, onUpdate }: Props) => {
   const [isEditing, beEditing] = useState(false);
-  const handleUpdate = (values: Partial<Account>) => {
+  const handleUpdate = (values: AccountInput) => {
     onUpdate(values);
     beEditing(false);
   };
@@ -32,7 +33,16 @@ export const AccountHeader = ({ account, onUpdate }: Props) => {
 };
 
 AccountHeader.defaultProps = {
-  onUpdate: (_values: Partial<Account>) => {
+  onUpdate: (_values: AccountInput) => {
     /* noop */
   },
+};
+
+AccountHeader.fragments = {
+  account: gql`
+    fragment AccountFields on Account {
+      id
+      name
+    }
+  `,
 };

--- a/client/src/AccountHeader.tsx
+++ b/client/src/AccountHeader.tsx
@@ -46,6 +46,7 @@ AccountHeader.defaultProps = {
 AccountHeader.fragments = {
   account: gql`
     fragment AccountFields on Account {
+      depositsPerYear
       id
       name
     }

--- a/client/src/AccountHeader.tsx
+++ b/client/src/AccountHeader.tsx
@@ -16,18 +16,23 @@ export const AccountHeader = ({ account, onUpdate }: Props) => {
     beEditing(false);
   };
 
-  return isEditing ? (
-    <AccountEditForm
-      account={account}
-      onCancel={() => beEditing(false)}
-      onUpdate={handleUpdate}
-    />
-  ) : (
+  return (
     <>
       <h2>{account.name}</h2>
-      <button onClick={() => beEditing(true)} type="button">
-        Edit
-      </button>
+      {isEditing ? (
+        <>
+          <h3>Account Settings</h3>
+          <AccountEditForm
+            account={account}
+            onCancel={() => beEditing(false)}
+            onUpdate={handleUpdate}
+          />
+        </>
+      ) : (
+        <button onClick={() => beEditing(true)} type="button">
+          Edit
+        </button>
+      )}
     </>
   );
 };

--- a/client/src/AccountHeader.tsx
+++ b/client/src/AccountHeader.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+
+import { AccountEditForm } from "./AccountEditForm";
+import { Account } from "./graphql";
+
+export type Props = {
+  account: Account;
+  onUpdate: (_values: Partial<Account>) => void;
+};
+
+export const AccountHeader = ({ account, onUpdate }: Props) => {
+  const [isEditing, beEditing] = useState(false);
+  const handleUpdate = (values: Partial<Account>) => {
+    onUpdate(values);
+    beEditing(false);
+  };
+
+  return isEditing ? (
+    <AccountEditForm
+      account={account}
+      onCancel={() => beEditing(false)}
+      onUpdate={handleUpdate}
+    />
+  ) : (
+    <>
+      <h2>{account.name}</h2>
+      <button onClick={() => beEditing(true)} type="button">
+        Edit
+      </button>
+    </>
+  );
+};
+
+AccountHeader.defaultProps = {
+  onUpdate: (_values: Partial<Account>) => {
+    /* noop */
+  },
+};

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import { Provider } from "urql";
@@ -17,7 +17,7 @@ export const App = () => {
       </header>
       <main>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
-          <React.Suspense fallback={<Loader />}>
+          <Suspense fallback={<Loader />}>
             <BrowserRouter>
               <Switch>
                 <Route path="/">
@@ -25,7 +25,7 @@ export const App = () => {
                 </Route>
               </Switch>
             </BrowserRouter>
-          </React.Suspense>
+          </Suspense>
         </ErrorBoundary>
       </main>
     </Provider>

--- a/client/src/Fund.tsx
+++ b/client/src/Fund.tsx
@@ -14,7 +14,7 @@ export const Fund = ({ fund }: Props) => (
 
 Fund.fragments = {
   fund: gql`
-    fragment FundParts on Fund {
+    fragment FundFields on Fund {
       icon
       id
       name

--- a/client/src/FundList.tsx
+++ b/client/src/FundList.tsx
@@ -24,7 +24,7 @@ FundList.fragments = {
   funds: gql`
     fragment AccountFunds on Account {
       funds {
-        ...FundParts
+        ...FundFields
       }
       id
       name

--- a/client/src/graphql.ts
+++ b/client/src/graphql.ts
@@ -32,6 +32,14 @@ export type Account = {
   name: Scalars["String"];
 };
 
+/** Account settings input */
+export type AccountInput = {
+  /** The account's unique ID */
+  id: Scalars["ID"];
+  /** The name of the account */
+  name: Scalars["String"];
+};
+
 /** A savings fund */
 export type Fund = {
   __typename?: "Fund";
@@ -41,6 +49,16 @@ export type Fund = {
   id: Scalars["ID"];
   /** The name of the fund */
   name: Scalars["String"];
+};
+
+export type RootMutationType = {
+  __typename?: "RootMutationType";
+  /** Update account settings */
+  updateAccount: Account;
+};
+
+export type RootMutationTypeUpdateAccountArgs = {
+  input: AccountInput;
 };
 
 export type RootQueryType = {

--- a/client/src/graphql.ts
+++ b/client/src/graphql.ts
@@ -24,6 +24,8 @@ export type Scalars = {
 /** A Freedom Account */
 export type Account = {
   __typename?: "Account";
+  /** How many regular deposits will be made per year? */
+  depositsPerYear: Scalars["Int"];
   /** The individual funds in the account */
   funds: Array<Fund>;
   /** The account's unique ID */
@@ -34,6 +36,8 @@ export type Account = {
 
 /** Account settings input */
 export type AccountInput = {
+  /** How many regular deposits will be made per year? */
+  depositsPerYear: Scalars["Int"];
   /** The account's unique ID */
   id: Scalars["ID"];
   /** The name of the account */
@@ -73,6 +77,7 @@ export type MyAccountQuery = {
   __typename?: "RootQueryType";
   myAccount: {
     __typename?: "Account";
+    depositsPerYear: number;
     id: string;
     name: string;
     funds: Array<{
@@ -90,11 +95,17 @@ export type UpdateAccountMutationVariables = Exact<{
 
 export type UpdateAccountMutation = {
   __typename?: "RootMutationType";
-  updateAccount: { __typename?: "Account"; id: string; name: string };
+  updateAccount: {
+    __typename?: "Account";
+    depositsPerYear: number;
+    id: string;
+    name: string;
+  };
 };
 
 export type AccountFieldsFragment = {
   __typename?: "Account";
+  depositsPerYear: number;
   id: string;
   name: string;
 };
@@ -115,6 +126,7 @@ export type AccountFundsFragment = {
 
 export const AccountFieldsFragmentDoc = gql`
   fragment AccountFields on Account {
+    depositsPerYear
     id
     name
   }

--- a/client/src/graphql.ts
+++ b/client/src/graphql.ts
@@ -73,8 +73,8 @@ export type MyAccountQuery = {
   __typename?: "RootQueryType";
   myAccount: {
     __typename?: "Account";
-    name: string;
     id: string;
+    name: string;
     funds: Array<{
       __typename?: "Fund";
       icon: string;
@@ -84,7 +84,22 @@ export type MyAccountQuery = {
   };
 };
 
-export type FundPartsFragment = {
+export type UpdateAccountMutationVariables = Exact<{
+  input: AccountInput;
+}>;
+
+export type UpdateAccountMutation = {
+  __typename?: "RootMutationType";
+  updateAccount: { __typename?: "Account"; id: string; name: string };
+};
+
+export type AccountFieldsFragment = {
+  __typename?: "Account";
+  id: string;
+  name: string;
+};
+
+export type FundFieldsFragment = {
   __typename?: "Fund";
   icon: string;
   id: string;
@@ -98,8 +113,14 @@ export type AccountFundsFragment = {
   funds: Array<{ __typename?: "Fund"; icon: string; id: string; name: string }>;
 };
 
-export const FundPartsFragmentDoc = gql`
-  fragment FundParts on Fund {
+export const AccountFieldsFragmentDoc = gql`
+  fragment AccountFields on Account {
+    id
+    name
+  }
+`;
+export const FundFieldsFragmentDoc = gql`
+  fragment FundFields on Fund {
     icon
     id
     name
@@ -108,20 +129,21 @@ export const FundPartsFragmentDoc = gql`
 export const AccountFundsFragmentDoc = gql`
   fragment AccountFunds on Account {
     funds {
-      ...FundParts
+      ...FundFields
     }
     id
     name
   }
-  ${FundPartsFragmentDoc}
+  ${FundFieldsFragmentDoc}
 `;
 export const MyAccountDocument = gql`
   query MyAccount {
     myAccount {
+      ...AccountFields
       ...AccountFunds
-      name
     }
   }
+  ${AccountFieldsFragmentDoc}
   ${AccountFundsFragmentDoc}
 `;
 
@@ -132,4 +154,19 @@ export function useMyAccountQuery(
     query: MyAccountDocument,
     ...options,
   });
+}
+export const UpdateAccountDocument = gql`
+  mutation UpdateAccount($input: AccountInput!) {
+    updateAccount(input: $input) {
+      ...AccountFields
+    }
+  }
+  ${AccountFieldsFragmentDoc}
+`;
+
+export function useUpdateAccountMutation() {
+  return Urql.useMutation<
+    UpdateAccountMutation,
+    UpdateAccountMutationVariables
+  >(UpdateAccountDocument);
 }

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 
 import "./index.css";
@@ -6,9 +6,9 @@ import { App } from "./App";
 import { reportWebVitals } from "./reportWebVitals";
 
 ReactDOM.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
   document.getElementById("root")
 );
 

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -3,3 +3,6 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
+import * as td from "testdouble";
+
+afterEach(td.reset);

--- a/e2e/cypress/integration/account.spec.ts
+++ b/e2e/cypress/integration/account.spec.ts
@@ -12,10 +12,13 @@ context("account settings", () => {
       cy.findByRole("heading", { name: "Initial Account" });
       cy.findByRole("button", { name: /edit/i }).click();
       cy.findByLabelText(/name/i).clear().type("My New Account");
+      cy.findByLabelText(/deposits/i)
+        .clear()
+        .type("18");
       cy.findByRole("button", { name: /update/i }).click();
 
       cy.findByRole("heading", { name: "My New Account" }).should("exist");
-      cy.findByRole("button", { name: /edit/i }).should("not.exist");
+      cy.findByRole("button", { name: /update/i }).should("not.exist");
     });
   });
 });

--- a/e2e/cypress/integration/account.spec.ts
+++ b/e2e/cypress/integration/account.spec.ts
@@ -1,0 +1,21 @@
+context("account settings", () => {
+  beforeEach(() => {
+    cy.visit("/");
+  });
+
+  describe("account settings", () => {
+    it("shows the account name", () => {
+      cy.findByRole("heading", { name: "Initial Account" }).should("exist");
+    });
+
+    it("allows editing account settings", () => {
+      cy.findByRole("heading", { name: "Initial Account" });
+      cy.findByRole("button", { name: /edit/i }).click();
+      cy.findByLabelText(/name/i).clear().type("My New Account");
+      cy.findByRole("button", { name: /update/i }).click();
+
+      cy.findByRole("heading", { name: "My New Account" }).should("exist");
+      cy.findByRole("button", { name: /edit/i }).should("not.exist");
+    });
+  });
+});

--- a/server/lib/freedom_account.ex
+++ b/server/lib/freedom_account.ex
@@ -12,10 +12,13 @@ defmodule FreedomAccount do
   alias FreedomAccount.Funds
 
   @type account :: Accounts.account()
+  @type account_params :: Accounts.account_params()
   @type fund :: Funds.fund()
+  @type update_error :: Accounts.update_error()
 
-  @callback list_funds(account) :: [fund]
+  @callback list_funds(account :: account) :: [fund]
   @callback my_account :: {:ok, account} | {:error, :not_found}
+  @callback update_account(params :: account_params) :: {:ok, account} | {:error, update_error}
 end
 
 defmodule FreedomAccount.Impl do
@@ -31,4 +34,7 @@ defmodule FreedomAccount.Impl do
 
   @impl FreedomAccount
   defdelegate my_account, to: Accounts, as: :only_account
+
+  @impl FreedomAccount
+  defdelegate update_account(params), to: Accounts
 end

--- a/server/lib/freedom_account/accounts.ex
+++ b/server/lib/freedom_account/accounts.ex
@@ -3,14 +3,34 @@ defmodule FreedomAccount.Accounts do
   Context for working with Freedom Accounts.
   """
 
+  alias Ecto.Changeset
   alias FreedomAccount.Accounts.Account
   alias FreedomAccount.Repo
 
   @type account :: Account.t()
+  @type account_params :: Account.params()
+  @type update_error :: :not_found | Changeset.t()
 
   @spec only_account :: {:ok, account} | {:error, :not_found}
   def only_account do
     case Repo.one(Account) do
+      nil -> {:error, :not_found}
+      account -> {:ok, account}
+    end
+  end
+
+  @spec update_account(params :: account_params) :: {:ok, account} | {:error, update_error}
+  def update_account(params) do
+    with {id, params} <- Map.pop(params, :id),
+         {:ok, account} <- account_with_id(id) do
+      account
+      |> Account.changeset(params)
+      |> Repo.update()
+    end
+  end
+
+  defp account_with_id(id) do
+    case Repo.get(Account, id) do
       nil -> {:error, :not_found}
       account -> {:ok, account}
     end

--- a/server/lib/freedom_account/accounts/account.ex
+++ b/server/lib/freedom_account/accounts/account.ex
@@ -9,13 +9,16 @@ defmodule FreedomAccount.Accounts.Account do
   alias FreedomAccount.Funds.Fund
   alias FreedomAccount.Schema
 
+  @type deposit_count :: non_neg_integer()
   @type id :: Schema.id()
   @type name :: String.t()
   @type params :: %{
+          deposits_per_year: deposit_count,
           id: id,
           name: name
         }
   @type t :: %__MODULE__{
+          deposits_per_year: deposit_count,
           funds: Schema.has_many(Fund.t()),
           id: id,
           inserted_at: DateTime.t() | nil,
@@ -28,6 +31,7 @@ defmodule FreedomAccount.Accounts.Account do
 
   schema "accounts" do
     has_many :funds, Fund
+    field :deposits_per_year, :integer
     field :name, :string
 
     timestamps()
@@ -36,8 +40,9 @@ defmodule FreedomAccount.Accounts.Account do
   @spec changeset(account :: Changeset.t() | Schema.t(), params :: params) :: Changeset.t()
   def changeset(account, params) do
     account
-    |> cast(params, [:name])
-    |> validate_required([:name])
+    |> cast(params, [:deposits_per_year, :name])
+    |> validate_required([:deposits_per_year, :name])
+    |> validate_number(:deposits_per_year, greater_than: 0)
     |> validate_length(:name, max: 50)
   end
 end

--- a/server/lib/freedom_account/accounts/account.ex
+++ b/server/lib/freedom_account/accounts/account.ex
@@ -5,11 +5,16 @@ defmodule FreedomAccount.Accounts.Account do
 
   use FreedomAccount.Schema
 
+  alias Ecto.Changeset
   alias FreedomAccount.Funds.Fund
   alias FreedomAccount.Schema
 
   @type id :: Schema.id()
   @type name :: String.t()
+  @type params :: %{
+          id: id,
+          name: name
+        }
   @type t :: %__MODULE__{
           funds: Schema.has_many(Fund.t()),
           id: id,
@@ -26,5 +31,13 @@ defmodule FreedomAccount.Accounts.Account do
     field :name, :string
 
     timestamps()
+  end
+
+  @spec changeset(account :: Changeset.t() | Schema.t(), params :: params) :: Changeset.t()
+  def changeset(account, params) do
+    account
+    |> cast(params, [:name])
+    |> validate_required([:name])
+    |> validate_length(:name, max: 50)
   end
 end

--- a/server/lib/freedom_account/schema.ex
+++ b/server/lib/freedom_account/schema.ex
@@ -10,9 +10,12 @@ defmodule FreedomAccount.Schema do
   @type belongs_to(t) :: Schema.belongs_to(t)
   @type has_many(t) :: Schema.has_many(t)
   @type id :: Ecto.UUID.t()
+  @type t :: Schema.t()
 
   defmacro __using__(_opts) do
     quote do
+      import Ecto.Changeset
+
       use Ecto.Schema
 
       import unquote(__MODULE__)

--- a/server/lib/freedom_account_web/resolvers/account.ex
+++ b/server/lib/freedom_account_web/resolvers/account.ex
@@ -6,10 +6,21 @@ defmodule FreedomAccountWeb.Resolvers.Account do
   use FreedomAccountWeb.Resolvers.Base
 
   @type account :: FreedomAccount.account()
+  @type account_input :: %{
+          input: FreedomAccount.account_params()
+        }
 
   @spec my_account(args :: %{}, resolution :: resolution) :: result(account)
   def my_account(_args, _resolution) do
     with {:ok, account} <- FreedomAccount.my_account() do
+      {:ok, account}
+    end
+  end
+
+  @spec update_account(args :: account_input, resolution :: resolution) ::
+          result(account)
+  def update_account(%{input: params}, _resolution) do
+    with {:ok, account} <- FreedomAccount.update_account(params) do
       {:ok, account}
     end
   end

--- a/server/lib/freedom_account_web/schema.ex
+++ b/server/lib/freedom_account_web/schema.ex
@@ -7,12 +7,21 @@ defmodule FreedomAccountWeb.Schema do
 
   import_types FreedomAccountWeb.Schema.AccountTypes
 
-  alias FreedomAccountWeb.Resolvers
+  alias FreedomAccountWeb.Resolvers.Account
 
   query do
     @desc "My freedom account"
     field :my_account, non_null(:account) do
-      resolve &Resolvers.Account.my_account/2
+      resolve &Account.my_account/2
+    end
+  end
+
+  mutation do
+    @desc "Update account settings"
+    field :update_account, non_null(:account) do
+      arg :input, non_null(:account_input)
+
+      resolve &Account.update_account/2
     end
   end
 end

--- a/server/lib/freedom_account_web/schema/account_types.ex
+++ b/server/lib/freedom_account_web/schema/account_types.ex
@@ -5,7 +5,7 @@ defmodule FreedomAccountWeb.Schema.AccountTypes do
 
   use Absinthe.Schema.Notation
 
-  alias FreedomAccountWeb.Resolvers
+  alias FreedomAccountWeb.Resolvers.Fund
 
   import_types FreedomAccountWeb.Schema.FundTypes
 
@@ -18,7 +18,15 @@ defmodule FreedomAccountWeb.Schema.AccountTypes do
 
     @desc "The individual funds in the account"
     field :funds, non_null(list_of(non_null(:fund))) do
-      resolve &Resolvers.Fund.list_funds/3
+      resolve &Fund.list_funds/3
     end
+  end
+
+  @desc "Account settings input"
+  input_object :account_input do
+    @desc "The account's unique ID"
+    field :id, non_null(:id)
+    @desc "The name of the account"
+    field :name, non_null(:string)
   end
 end

--- a/server/lib/freedom_account_web/schema/account_types.ex
+++ b/server/lib/freedom_account_web/schema/account_types.ex
@@ -15,6 +15,8 @@ defmodule FreedomAccountWeb.Schema.AccountTypes do
     field :id, non_null(:id)
     @desc "The name of the account"
     field :name, non_null(:string)
+    @desc "How many regular deposits will be made per year?"
+    field :deposits_per_year, non_null(:integer)
 
     @desc "The individual funds in the account"
     field :funds, non_null(list_of(non_null(:fund))) do
@@ -28,5 +30,7 @@ defmodule FreedomAccountWeb.Schema.AccountTypes do
     field :id, non_null(:id)
     @desc "The name of the account"
     field :name, non_null(:string)
+    @desc "How many regular deposits will be made per year?"
+    field :deposits_per_year, non_null(:integer)
   end
 end

--- a/server/priv/repo/migrations/20211117040101_add_deposits_per_year_to_account.exs
+++ b/server/priv/repo/migrations/20211117040101_add_deposits_per_year_to_account.exs
@@ -1,0 +1,9 @@
+defmodule FreedomAccount.Repo.Migrations.AddDepositsPerYearToAccount do
+  use Ecto.Migration
+
+  def change do
+    alter table("accounts") do
+      add :deposits_per_year, :integer, default: 24, null: false
+    end
+  end
+end

--- a/server/test/freedom_account/accounts_test.exs
+++ b/server/test/freedom_account/accounts_test.exs
@@ -2,6 +2,7 @@ defmodule FreedomAccount.AccountsTest do
   use FreedomAccount.DataCase, async: true
 
   alias FreedomAccount.Accounts
+  alias FreedomAccount.Accounts.Account
 
   describe "retrieving the only account" do
     test "returns the single account if present" do
@@ -14,12 +15,42 @@ defmodule FreedomAccount.AccountsTest do
       assert {:error, :not_found} = Accounts.only_account()
     end
 
-    test "returns error tuple if more than one account" do
+    test "raises if more than one account" do
       insert_list(2, :account)
 
       assert_raise Ecto.MultipleResultsError, fn ->
         Accounts.only_account()
       end
+    end
+  end
+
+  describe "updating account settings" do
+    test "returns the updated account" do
+      account = insert(:account)
+      account_id = account.id
+      name = "NEW NAME"
+      params = %{id: account_id, name: name}
+
+      assert {:ok,
+              %Account{
+                id: ^account_id,
+                name: ^name
+              }} = Accounts.update_account(params)
+    end
+
+    test "returns not found error if no matching account" do
+      params = %{id: Ecto.UUID.generate(), name: "NEW NAME"}
+
+      assert {:error, :not_found} = Accounts.update_account(params)
+    end
+
+    test "returns changeset error if name is blank" do
+      account = insert(:account)
+      params = %{id: account.id, name: ""}
+
+      assert {:error, changeset} = Accounts.update_account(params)
+
+      assert "can't be blank" in errors_on(changeset).name
     end
   end
 end

--- a/server/test/freedom_account_web/schema_test.exs
+++ b/server/test/freedom_account_web/schema_test.exs
@@ -4,6 +4,7 @@ defmodule FreedomAccountWeb.SchemaTest do
   @account_query """
   query MyAccount {
     myAccount {
+      depositsPerYear
       funds {
         icon
         id
@@ -40,6 +41,7 @@ defmodule FreedomAccountWeb.SchemaTest do
     assert %{
              "data" => %{
                "myAccount" => %{
+                 "depositsPerYear" => account.deposits_per_year,
                  "funds" => expected_funds,
                  "id" => account.id,
                  "name" => account.name
@@ -51,6 +53,7 @@ defmodule FreedomAccountWeb.SchemaTest do
   @update_account_mutation """
   mutation UpdateAccount($input: AccountInput!) {
     updateAccount(input: $input) {
+      depositsPerYear
       id
       name
     }
@@ -59,9 +62,10 @@ defmodule FreedomAccountWeb.SchemaTest do
 
   test "mutation: updateAccount", %{conn: conn} do
     account = build(:account)
+    deposits_per_year = 26
     name = "NEW NAME"
-    updated_account = %{account | name: name}
-    params = %{id: account.id, name: name}
+    updated_account = %{account | deposits_per_year: deposits_per_year, name: name}
+    params = %{deposits_per_year: deposits_per_year, id: account.id, name: name}
 
     FreedomAccountMock
     |> expect(:update_account, fn ^params -> {:ok, updated_account} end)
@@ -77,6 +81,7 @@ defmodule FreedomAccountWeb.SchemaTest do
     assert %{
              "data" => %{
                "updateAccount" => %{
+                 "depositsPerYear" => deposits_per_year,
                  "id" => account.id,
                  "name" => name
                }

--- a/server/test/freedom_account_web/schema_test.exs
+++ b/server/test/freedom_account_web/schema_test.exs
@@ -2,8 +2,8 @@ defmodule FreedomAccountWeb.SchemaTest do
   use FreedomAccountWeb.ConnCase, async: true
 
   @account_query """
-  query account {
-    my_account {
+  query MyAccount {
+    myAccount {
       funds {
         icon
         id
@@ -15,7 +15,7 @@ defmodule FreedomAccountWeb.SchemaTest do
   }
   """
 
-  test "query: account", %{conn: conn} do
+  test "query: myAccount", %{conn: conn} do
     account = build(:account)
     funds = build_list(3, :fund)
 
@@ -39,10 +39,46 @@ defmodule FreedomAccountWeb.SchemaTest do
 
     assert %{
              "data" => %{
-               "my_account" => %{
+               "myAccount" => %{
                  "funds" => expected_funds,
                  "id" => account.id,
                  "name" => account.name
+               }
+             }
+           } == response
+  end
+
+  @update_account_mutation """
+  mutation UpdateAccount($input: AccountInput!) {
+    updateAccount(input: $input) {
+      id
+      name
+    }
+  }
+  """
+
+  test "mutation: updateAccount", %{conn: conn} do
+    account = build(:account)
+    name = "NEW NAME"
+    updated_account = %{account | name: name}
+    params = %{id: account.id, name: name}
+
+    FreedomAccountMock
+    |> expect(:update_account, fn ^params -> {:ok, updated_account} end)
+
+    response =
+      conn
+      |> post("/api", %{
+        query: @update_account_mutation,
+        variables: %{input: params}
+      })
+      |> json_response(200)
+
+    assert %{
+             "data" => %{
+               "updateAccount" => %{
+                 "id" => account.id,
+                 "name" => name
                }
              }
            } == response

--- a/server/test/support/factory.ex
+++ b/server/test/support/factory.ex
@@ -80,6 +80,7 @@ defmodule FreedomAccount.Factory do
 
   def account_factory do
     %Account{
+      deposits_per_year: Faker.random_between(12, 26),
       id: Ecto.UUID.generate(),
       name: Faker.Company.name()
     }


### PR DESCRIPTION
Allow editing of account settings, including name and # of deposits/year.

Account name header gets an edit button that displays an edit form just below.

Minimal styling for now; trying to get the app functional first, then will circle back around and improve the UI and querying behavior.

Closes #87 

**Checklist**

Have you added the following where appropriate?

- [x] Unit tests for new server code?
- [x] Unit tests for new client code?
- [x] End-to-end happy-path tests?
- [ ] Proper error handling?
- [ ] Minimize React re-rendering?
- [x] Accessibility for new UI?
- [ ] Appropriate animations for new UI?
- [ ] Optimistic updates for API calls?
- [ ] Rollback optimistic update when API call fails?
